### PR TITLE
Allow adding missing environment variables for Preflight in DB setup script

### DIFF
--- a/scripts/alpine-postgresql-setup-and-start.sh
+++ b/scripts/alpine-postgresql-setup-and-start.sh
@@ -8,8 +8,10 @@ echo "Setting up PostgreSQL on Alpine Linux..."
 export PGHOST=/postgres-volume/run/postgresql
 export PGDATA="$PGHOST/data"
 
-# If the project has more environment variables then PGHOST, PGDATABASE, PGUSERNAME and PGPASSWORD, add them to the Array below
-# e.g. echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
+# If the project has more environment variables than
+# PGHOST, PGDATABASE, PGUSERNAME and PGPASSWORD, add
+# strings of their names to the array below, eg:
+# echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
 echo "PREFLIGHT_ENVIRONMENT_VARIABLES:"
 echo '[]'
 

--- a/scripts/alpine-postgresql-setup-and-start.sh
+++ b/scripts/alpine-postgresql-setup-and-start.sh
@@ -8,6 +8,12 @@ echo "Setting up PostgreSQL on Alpine Linux..."
 export PGHOST=/postgres-volume/run/postgresql
 export PGDATA="$PGHOST/data"
 
+# If the project requires additional environment variables beyond PGHOST, PGDATABASE, PGUSERNAME, and PGPASSWORD,
+# add them to the array below. Example:
+# echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
+echo "PREFLIGHT_ENVIRONMENT_VARIABLES:"
+echo '[]'
+
 echo "Adding exclusive data directory permissions for postgres user..."
 chmod 0700 "$PGDATA"
 
@@ -21,7 +27,8 @@ echo "Enabling connections on all available IP interfaces..."
 echo "listen_addresses='*'" >> "$PGDATA/postgresql.conf"
 
 echo "Starting PostgreSQL..."
-pg_ctl start -D "$PGDATA"
+pg_ctl start --pgdata="$PGDATA" --log="/tmp/postgres_startup.log"
+cat "/tmp/postgres_startup.log"
 
 echo "Creating database, user and schema..."
 psql -U postgres postgres << SQL

--- a/scripts/alpine-postgresql-setup-and-start.sh
+++ b/scripts/alpine-postgresql-setup-and-start.sh
@@ -8,9 +8,8 @@ echo "Setting up PostgreSQL on Alpine Linux..."
 export PGHOST=/postgres-volume/run/postgresql
 export PGDATA="$PGHOST/data"
 
-# If the project requires additional environment variables beyond PGHOST, PGDATABASE, PGUSERNAME, and PGPASSWORD,
-# add them to the array below. Example:
-# echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
+# If the project has more environment variables then PGHOST, PGDATABASE, PGUSERNAME and PGPASSWORD, add them to the Array below
+# e.g. echo '[ "CLOUDINARY_API_KEY", "CLOUDINARY_API_SECRET" ]'
 echo "PREFLIGHT_ENVIRONMENT_VARIABLES:"
 echo '[]'
 
@@ -27,8 +26,9 @@ echo "Enabling connections on all available IP interfaces..."
 echo "listen_addresses='*'" >> "$PGDATA/postgresql.conf"
 
 echo "Starting PostgreSQL..."
-pg_ctl start --pgdata="$PGDATA" --log="/tmp/postgres_startup.log"
-cat "/tmp/postgres_startup.log"
+pg_ctl start --pgdata="$PGDATA" --log="/tmp/postgresql-server-start.log"
+sleep 1
+cat "/tmp/postgresql-server-start.log"
 
 echo "Creating database, user and schema..."
 psql -U postgres postgres << SQL

--- a/scripts/fly-io-start.sh
+++ b/scripts/fly-io-start.sh
@@ -9,7 +9,7 @@ if [[ ! -f /postgres-volume/run/postgresql/data/postgresql.conf ]]; then
 fi
 
 echo "Setting up PostgreSQL on Fly.io..."
-su postgres -c "pg_ctl start -D /postgres-volume/run/postgresql/data"
+su postgres -c "pg_ctl start --pgdata=/postgres-volume/run/postgresql/data"
 
 pnpm migrate up
 ./node_modules/.bin/next start


### PR DESCRIPTION
Follow up 
- https://github.com/upleveled/preflight/pull/632

Preflight fails when `dotenv-safe` detects missing environment variables. This update to `alpine-postgresql-setup-and-start.sh` lets students add additional environment variables needed for Preflight. 